### PR TITLE
Return datetimes as strings, not epoch dates

### DIFF
--- a/gsheets/backend.py
+++ b/gsheets/backend.py
@@ -62,7 +62,8 @@ def spreadsheet(service, id):
 
 def values(service, id, ranges):
     """Fetch and return spreadsheet cell values with Google sheets API."""
-    params = {'majorDimension': 'ROWS', 'valueRenderOption': 'UNFORMATTED_VALUE'}
+    params = {'majorDimension': 'ROWS', 'valueRenderOption': 'UNFORMATTED_VALUE',
+              'dateTimeRenderOption': 'FORMATTED_STRING'}
     params.update(spreadsheetId=id, ranges=ranges)
     response = service.spreadsheets().values().batchGet(**params).execute()
     return response['valueRanges']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,5 +127,5 @@ def spreadsheet_values(apiclient, spreadsheet):
     batchGet.assert_called_once_with(
         spreadsheetId=spreadsheet['spreadsheet']['spreadsheetId'],
         ranges=[s['properties']['title'] for s in spreadsheet['spreadsheet']['sheets']],
-        majorDimension='ROWS', valueRenderOption='UNFORMATTED_VALUE')
+        majorDimension='ROWS', valueRenderOption='UNFORMATTED_VALUE', dateTimeRenderOption='FORMATTED_STRING')
     batchGet.return_value.execute.assert_called_once_with()


### PR DESCRIPTION
Fixes #2.
Google Sheets datetimes are saved as days since December 30th, 1899: changed the API request to return the actual formatted string, instead of the epoch date.

https://developers.google.com/sheets/api/guides/concepts#datetime_serial_numbers