### PR TITLE
quote worksheet names with spaces or special characters

### DIFF
--- a/gsheets/backend.py
+++ b/gsheets/backend.py
@@ -21,6 +21,8 @@ FILEORDER = 'folder,name,createdTime'
 IS_ALPHANUMERIC_A1 = re.compile(r'[a-zA-Z]{1,3}'  # last column 'ZZZ' (18_278)
                                 r'\d{1,}').fullmatch
 
+IS_SAFE_UNQUOTED = re.compile(r'\w+').fullmatch  # letters/digits/underscore only
+
 
 def build_service(name=None, **kwargs):
     """Return a service endpoint for interacting with a Google API."""
@@ -93,16 +95,21 @@ def values(service, id, ranges):
 def quote(worksheet_name: str) -> str:
     """Return ``worksheet_name``, single-quote if needed.
 
+    Sheet names must be single-quoted in A1-notation ranges if they contain
+    spaces or other special (non-word) characters, or if they would
+    otherwise be ambiguous with a cell/range reference (e.g. ``'DKC3'``).
+
+    see https://developers.google.com/sheets/api/guides/concepts#expandable-1
+
     >>> quote('spam')
     'spam'
 
     >>> quote('spam spam')
-    'spam spam'
+    "'spam spam'"
 
     >>> quote('DKC3')
     "'DKC3'"
     """
-    if IS_ALPHANUMERIC_A1(worksheet_name):
-        # https://developers.google.com/sheets/api/guides/concepts#expandable-1
-        return f"'{worksheet_name}'"
-    return worksheet_name
+    if IS_SAFE_UNQUOTED(worksheet_name) and not IS_ALPHANUMERIC_A1(worksheet_name):
+        return worksheet_name
+    return f"'{worksheet_name}'"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -3,6 +3,21 @@ import pytest
 from gsheets import backend
 
 
+@pytest.mark.parametrize(('name', 'expected'), [
+    ('spam', 'spam'),
+    ('Tabellenblatt2', 'Tabellenblatt2'),
+    ('2024', '2024'),
+    ('a_b', 'a_b'),
+    ('DKC3', "'DKC3'"),
+    ('spam spam', "'spam spam'"),
+    ('Sheet 1', "'Sheet 1'"),
+    ('Q1 Report', "'Q1 Report'"),
+    ('Sales!', "'Sales!'"),
+])
+def test_quote(name, expected):
+    assert backend.quote(name) == expected
+
+
 def test_build_service(mocker, serviceName='spam', version='v1'):  # noqa: N803
     build = mocker.patch('apiclient.discovery.build', autospec=True)
 


### PR DESCRIPTION
Follow-up to #21. When that issue was fixed, the relevant part of Google's docs was quoted here:

> 'My Custom Sheet'!A:A refers to all the cells in a sheet named "My Custom Sheet." Single quotes are required for sheet names with spaces, special characters, or an alphanumeric combination.

The shipped fix (`IS_ALPHANUMERIC_A1`) only covers the "alphanumeric combination" half of that rule — a name like `Sheet 1` or `Q1 Report` still passes through `quote()` unquoted, and the Sheets API rejects the resulting range with a 400 at `values().batchGet()` time.

This completes the other half: quote unless the name is composed entirely of word characters (letters/digits/underscore) AND doesn't collide with the cell-reference pattern.

### Test plan
- pytest: 126 passing / 100% coverage before, 135 passing / 100% coverage after, including 9 new parametrized cases (plain names, cell-reference-like names, names with spaces/punctuation).

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.